### PR TITLE
Fix Table compilation error

### DIFF
--- a/src/Table.h
+++ b/src/Table.h
@@ -4,6 +4,7 @@
 //References//
 //----------//
 #include "Implication.h"
+#include "Inference.h"
 
 //Parameters//
 //----------//


### PR DESCRIPTION
The following warning and error occur because `Inference.h` wasn't included:
```
./src/Table.c:44:35: warning: implicit declaration of function 'Inference_ImplicationRevision' is invalid in C99
      [-Wimplicit-function-declaration]
            Implication revised = Inference_ImplicationRevision(closest, imp);
                                  ^
./src/Table.c:44:25: error: initializing 'Implication' with an expression of incompatible type 'int'
            Implication revised = Inference_ImplicationRevision(closest, imp);
                        ^         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 warning and 1 error generated.
```

