### PR TITLE
fix incompatible pointer type warnings in SDR.c

### DIFF
--- a/src/SDR.c
+++ b/src/SDR.c
@@ -36,7 +36,7 @@ void SDR_PrintWhereTrue(SDR *sdr)
     ITERATE_SDR_BITS(i,j,
         if (SDR_ReadBitInBlock(sdr,i,j)) 
         {
-            printf("[%d](%d,%d)\n", i*SDR_BLOCK_SIZE+j, i, j);
+            printf("[%lu](%d,%d)\n", i*SDR_BLOCK_SIZE+j, i, j);
         }
     )
     printf("===\n");
@@ -133,17 +133,17 @@ SDR SDR_Tuple(SDR *a, SDR *b)
 
 SDR SDR_TupleGetFirstElement(SDR *compound, SDR *secondElement)
 {
-    SDR bPerm = SDR_Permute(secondElement, &SDR_permP);
-    SDR sdrxor = SDR_Xor(&bPerm,compound);
-    SDR a = SDR_Permute(&sdrxor, &SDR_permS_inv);
+    SDR bPerm = SDR_Permute(secondElement, SDR_permP);
+    SDR sdrxor = SDR_Xor(&bPerm, compound);
+    SDR a = SDR_Permute(&sdrxor, SDR_permS_inv);
     return a;
 }
 
 SDR SDR_TupleGetSecondElement(SDR *compound, SDR *firstElement)
 {
-    SDR aPerm = SDR_Permute(firstElement, &SDR_permS);
-    SDR sdrxor = SDR_Xor(&aPerm,compound);
-    SDR b = SDR_Permute(&sdrxor, &SDR_permP_inv);
+    SDR aPerm = SDR_Permute(firstElement, SDR_permS);
+    SDR sdrxor = SDR_Xor(&aPerm, compound);
+    SDR b = SDR_Permute(&sdrxor, SDR_permP_inv);
     return b;
 }
 
@@ -231,6 +231,6 @@ SDR SDR_Permute(SDR *sdr, int *permutation)
 
 void SDR_INIT()
 {
-    SDR_GeneratePermutation(&SDR_permS, &SDR_permS_inv);
-    SDR_GeneratePermutation(&SDR_permP, &SDR_permP_inv);
+    SDR_GeneratePermutation(SDR_permS, SDR_permS_inv);
+    SDR_GeneratePermutation(SDR_permP, SDR_permP_inv);
 }


### PR DESCRIPTION
This fixed the following warnings in `SDR.c`:

```
./src/SDR.c:39:37: warning: format specifies type 'int' but the argument has type 'unsigned long' [-Wformat]
            printf("[%d](%d,%d)\n", i*SDR_BLOCK_SIZE+j, i, j);
            ~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~
                     %lu
./src/SDR.h:50:13: note: expanded from macro 'ITERATE_SDR_BITS'
            CODE\
            ^~~~
./src/SDR.c:136:44: warning: incompatible pointer types passing 'int (*)[2048]' to parameter of type 'int *' [-Wincompatible-pointer-types]
    SDR bPerm = SDR_Permute(secondElement, &SDR_permP);
                                           ^~~~~~~~~~
./src/SDR.h:85:32: note: passing argument to parameter 'permutation' here
SDR SDR_Permute(SDR *sdr, int *permutation);
                               ^
./src/SDR.c:138:34: warning: incompatible pointer types passing 'int (*)[2048]' to parameter of type 'int *' [-Wincompatible-pointer-types]
    SDR a = SDR_Permute(&sdrxor, &SDR_permS_inv);
                                 ^~~~~~~~~~~~~~
./src/SDR.h:85:32: note: passing argument to parameter 'permutation' here
SDR SDR_Permute(SDR *sdr, int *permutation);
                               ^
./src/SDR.c:144:43: warning: incompatible pointer types passing 'int (*)[2048]' to parameter of type 'int *' [-Wincompatible-pointer-types]
    SDR aPerm = SDR_Permute(firstElement, &SDR_permS);
                                          ^~~~~~~~~~
./src/SDR.h:85:32: note: passing argument to parameter 'permutation' here
SDR SDR_Permute(SDR *sdr, int *permutation);
                               ^
./src/SDR.c:146:34: warning: incompatible pointer types passing 'int (*)[2048]' to parameter of type 'int *' [-Wincompatible-pointer-types]
    SDR b = SDR_Permute(&sdrxor, &SDR_permP_inv);
                                 ^~~~~~~~~~~~~~
./src/SDR.h:85:32: note: passing argument to parameter 'permutation' here
SDR SDR_Permute(SDR *sdr, int *permutation);
                               ^
./src/SDR.c:234:29: warning: incompatible pointer types passing 'int (*)[2048]' to parameter of type 'int *' [-Wincompatible-pointer-types]
    SDR_GeneratePermutation(&SDR_permS, &SDR_permS_inv);
                            ^~~~~~~~~~
./src/SDR.c:199:35: note: passing argument to parameter 'perm' here
void SDR_GeneratePermutation(int *perm, int *perm_inverse)
                                  ^
./src/SDR.c:234:41: warning: incompatible pointer types passing 'int (*)[2048]' to parameter of type 'int *' [-Wincompatible-pointer-types]
    SDR_GeneratePermutation(&SDR_permS, &SDR_permS_inv);
                                        ^~~~~~~~~~~~~~
./src/SDR.c:199:46: note: passing argument to parameter 'perm_inverse' here
void SDR_GeneratePermutation(int *perm, int *perm_inverse)
                                             ^
./src/SDR.c:235:29: warning: incompatible pointer types passing 'int (*)[2048]' to parameter of type 'int *' [-Wincompatible-pointer-types]
    SDR_GeneratePermutation(&SDR_permP, &SDR_permP_inv);
                            ^~~~~~~~~~
./src/SDR.c:199:35: note: passing argument to parameter 'perm' here
void SDR_GeneratePermutation(int *perm, int *perm_inverse)
                                  ^
./src/SDR.c:235:41: warning: incompatible pointer types passing 'int (*)[2048]' to parameter of type 'int *' [-Wincompatible-pointer-types]
    SDR_GeneratePermutation(&SDR_permP, &SDR_permP_inv);
                                        ^~~~~~~~~~~~~~
./src/SDR.c:199:46: note: passing argument to parameter 'perm_inverse' here
void SDR_GeneratePermutation(int *perm, int *perm_inverse)
                                             ^
9 warnings generated.
```