### PR TITLE
fix printf warnings for Stamp

### DIFF
--- a/src/Stamp.c
+++ b/src/Stamp.c
@@ -79,7 +79,7 @@ void Stamp_print(Stamp *stamp)
         {
             break;
         }
-        printf("%d,", stamp->evidentalBase[i]);
+        printf("%ld,", stamp->evidentalBase[i]);
     }
     printf("\n");
 }

--- a/src/Stamp.h
+++ b/src/Stamp.h
@@ -4,6 +4,7 @@
 //References//
 //----------//
 #include <stdbool.h>
+#include <stdio.h>
 
 //Parameters//
 //----------//


### PR DESCRIPTION
This addresses the following warnings for Stamp:
```
./src/Stamp.c:75:5: warning: implicitly declaring library function 'printf' with type 'int (const char *, ...)' [-Wimplicit-function-declaration]
    printf("stamp=");
    ^
./src/Stamp.c:75:5: note: include the header <stdio.h> or explicitly provide a declaration for 'printf'
./src/Stamp.c:82:23: warning: format specifies type 'int' but the argument has type 'long' [-Wformat]
        printf("%d,", stamp->evidentalBase[i]);
                ~~    ^~~~~~~~~~~~~~~~~~~~~~~
                %ld
2 warnings generated.
```