### PR TITLE
fix abs/labs warnings in Truth & Inference

### DIFF
--- a/src/Inference.c
+++ b/src/Inference.c
@@ -32,7 +32,7 @@ Implication Inference_BeliefInduction(Event *a, Event *b)
 Event Inference_EventRevision(Event *a, Event *b)
 {
     DERIVATION_STAMP_AND_TIME(a,b)
-    if(abs(a->occurrenceTime - b->occurrenceTime) > REVISION_MAX_OCCURRENCE_DISTANCE)
+    if(labs(a->occurrenceTime - b->occurrenceTime) > REVISION_MAX_OCCURRENCE_DISTANCE)
     {
         return (Event) {0};
     }

--- a/src/Inference.h
+++ b/src/Inference.h
@@ -15,6 +15,7 @@
 //References//
 //-----------//
 #include <stdbool.h>
+#include <stdlib.h>
 #include "SDR.h"
 #include "Stamp.h"
 #include "Event.h"

--- a/src/Truth.c
+++ b/src/Truth.c
@@ -84,6 +84,6 @@ Truth Truth_Eternalize(Truth v)
 
 Truth Truth_Projection(Truth v, long originalTime, long targetTime)
 {
-    double difference = abs(targetTime - originalTime);
+    double difference = labs(targetTime - originalTime);
     return (Truth) { .frequency = v.frequency, .confidence = v.confidence * pow(TRUTH_PROJECTION_DECAY,difference)};
 }

--- a/src/Truth.h
+++ b/src/Truth.h
@@ -8,6 +8,7 @@
 //References//
 //-----------//
 #include <math.h>
+#include <stdlib.h>
 
 //Data structure//
 //--------------//


### PR DESCRIPTION
This fixes the following warnings:
```
./src/Inference.c:35:8: warning: absolute value function 'abs' given an argument of type 'long' but has parameter of type 'int' which may cause truncation of value [-Wabsolute-value]
    if(abs(a->occurrenceTime - b->occurrenceTime) > REVISION_MAX_OCCURRENCE_DISTANCE)
       ^
./src/Inference.c:35:8: note: use function 'labs' instead
    if(abs(a->occurrenceTime - b->occurrenceTime) > REVISION_MAX_OCCURRENCE_DISTANCE)
       ^~~
       labs

./src/Truth.c:87:25: warning: implicitly declaring library function 'abs' with type 'int (int)' [-Wimplicit-function-declaration]
    double difference = abs(targetTime - originalTime);
                        ^
./src/Truth.c:87:25: note: include the header <stdlib.h> or explicitly provide a declaration for 'abs'
./src/Truth.c:87:25: warning: absolute value function 'abs' given an argument of type 'long' but has parameter of type 'int' which may cause truncation of value [-Wabsolute-value]
    double difference = abs(targetTime - originalTime);
                        ^
./src/Truth.c:87:25: note: use function 'labs' instead
    double difference = abs(targetTime - originalTime);
                        ^~~
                        labs
./src/Truth.c:87:25: note: include the header <stdlib.h> or explicitly provide a declaration for 'labs'
```