### PR TITLE
Fix misc warnings

### DIFF
--- a/src/Cycle.c
+++ b/src/Cycle.c
@@ -9,10 +9,10 @@ void composition(Concept *B, Concept *A, Event *b)
         Event *a = &A->event_beliefs.array[0]; //most recent, highest revised
         if(a->type != EVENT_TYPE_DELETED && !Stamp_checkOverlap(&a->stamp, &b->stamp))
         {
-            Implication implication = Inference_BeliefInduction(&a, &b);
+            Implication implication = Inference_BeliefInduction(a, b);
             Table_AddAndRevise(&B->precondition_beliefs, &implication);
             Table_AddAndRevise(&A->postcondition_beliefs, &implication);
-            Event sequence = b->occurrenceTime > a->occurrenceTime ? Inference_BeliefIntersection(&a, &b) : Inference_BeliefIntersection(&b, &a);
+            Event sequence = b->occurrenceTime > a->occurrenceTime ? Inference_BeliefIntersection(a, b) : Inference_BeliefIntersection(b, a);
             Memory_addEvent(&sequence);
         }
     }
@@ -26,7 +26,7 @@ void decomposition(Concept *c, Event *e)
         Implication postcon = c->postcondition_beliefs.array[0];
         if(!Stamp_checkOverlap(&e->stamp, &postcon.stamp))
         {
-            Event res = e->type == EVENT_TYPE_BELIEF ? Inference_BeliefDeduction(&e, &postcon) : Inference_GoalAbduction(&e, &postcon);
+            Event res = e->type == EVENT_TYPE_BELIEF ? Inference_BeliefDeduction(e, &postcon) : Inference_GoalAbduction(e, &postcon);
             res.attention = Attention_deriveEvent(&c->attention, &postcon.truth);
             Memory_addEvent(&res);
             //add negative evidence to the used predictive hypothesis (assumption of failure, for extinction)
@@ -40,7 +40,7 @@ void decomposition(Concept *c, Event *e)
         Implication precon = c->precondition_beliefs.array[0];
         if(!Stamp_checkOverlap(&e->stamp, &precon.stamp))
         {
-            Event res = e->type == EVENT_TYPE_BELIEF ? Inference_BeliefAbduction(&e, &precon) : Inference_GoalDeduction(&e, &precon);
+            Event res = e->type == EVENT_TYPE_BELIEF ? Inference_BeliefAbduction(e, &precon) : Inference_GoalDeduction(e, &precon);
             res.attention = Attention_deriveEvent(&c->attention, &precon.truth);
             Memory_addEvent(&res);
         }
@@ -55,7 +55,7 @@ void cycle()
         Item item = PriorityQueue_PopMax(&events);
         Event *e = item.address;
         //determine the concept it is related to
-        int closest_concept_i = Memory_getClosestConcept(&e);
+        int closest_concept_i = Memory_getClosestConcept(e);
         if(closest_concept_i == MEMORY_MATCH_NO_CONCEPT)
         {
             continue;

--- a/src/Encode.c
+++ b/src/Encode.c
@@ -28,7 +28,7 @@ unsigned long hash(unsigned char *str)
 {
     unsigned long hash = 5381;
     int c;
-    while (c = *str++)
+    while ((c = *str++))
     {
         hash = ((hash << 5) + hash) + c; /* hash * 33 + c */
     }

--- a/src/main.c
+++ b/src/main.c
@@ -8,7 +8,7 @@ void assert(bool b, char* message)
 {
     if(!b)
     {
-        printf(message);
+        printf("%s", message);
         printf("\nTest failed.\n");
         exit(1);
     }


### PR DESCRIPTION
This fixes the following warnings:
```
./src/Encode.c:31:14: warning: using the result of an assignment as a condition without parentheses [-Wparentheses]
    while (c = *str++)
           ~~^~~~~~~~
./src/Encode.c:31:14: note: place parentheses around the assignment to silence this warning
    while (c = *str++)
             ^
           (         )
./src/Encode.c:31:14: note: use '==' to turn this assignment into an equality comparison
    while (c = *str++)
             ^
             ==
./src/Cycle.c:12:65: warning: incompatible pointer types passing 'Event **' to parameter of type 'Event *'; remove & [-Wincompatible-pointer-types]
            Implication implication = Inference_BeliefInduction(&a, &b);
                                                                ^~
./src/Inference.h:30:46: note: passing argument to parameter 'a' here
Implication Inference_BeliefInduction(Event *a, Event *b);
                                             ^
./src/Cycle.c:12:69: warning: incompatible pointer types passing 'Event **' to parameter of type 'Event *'; remove & [-Wincompatible-pointer-types]
            Implication implication = Inference_BeliefInduction(&a, &b);
                                                                    ^~
./src/Inference.h:30:56: note: passing argument to parameter 'b' here
Implication Inference_BeliefInduction(Event *a, Event *b);
                                                       ^
./src/Cycle.c:15:99: warning: incompatible pointer types passing 'Event **' to parameter of type 'Event *'; remove & [-Wincompatible-pointer-types]
            Event sequence = b->occurrenceTime > a->occurrenceTime ? Inference_BeliefIntersection(&a, &b) : Inference_BeliefIntersection(&b, &a);
                                                                                                  ^~
./src/Inference.h:28:43: note: passing argument to parameter 'a' here
Event Inference_BeliefIntersection(Event *a, Event *b);
                                          ^
./src/Cycle.c:15:103: warning: incompatible pointer types passing 'Event **' to parameter of type 'Event *'; remove & [-Wincompatible-pointer-types]
            Event sequence = b->occurrenceTime > a->occurrenceTime ? Inference_BeliefIntersection(&a, &b) : Inference_BeliefIntersection(&b, &a);
                                                                                                      ^~
./src/Inference.h:28:53: note: passing argument to parameter 'b' here
Event Inference_BeliefIntersection(Event *a, Event *b);
                                                    ^
./src/Cycle.c:15:138: warning: incompatible pointer types passing 'Event **' to parameter of type 'Event *'; remove & [-Wincompatible-pointer-types]
            Event sequence = b->occurrenceTime > a->occurrenceTime ? Inference_BeliefIntersection(&a, &b) : Inference_BeliefIntersection(&b, &a);
                                                                                                                                         ^~
./src/Inference.h:28:43: note: passing argument to parameter 'a' here
Event Inference_BeliefIntersection(Event *a, Event *b);
                                          ^
./src/Cycle.c:15:142: warning: incompatible pointer types passing 'Event **' to parameter of type 'Event *'; remove & [-Wincompatible-pointer-types]
            Event sequence = b->occurrenceTime > a->occurrenceTime ? Inference_BeliefIntersection(&a, &b) : Inference_BeliefIntersection(&b, &a);
                                                                                                                                             ^~
./src/Inference.h:28:53: note: passing argument to parameter 'b' here
Event Inference_BeliefIntersection(Event *a, Event *b);
                                                    ^
./src/Cycle.c:29:82: warning: incompatible pointer types passing 'Event **' to parameter of type 'Event *'; remove & [-Wincompatible-pointer-types]
            Event res = e->type == EVENT_TYPE_BELIEF ? Inference_BeliefDeduction(&e, &postcon) : Inference_GoalAbduction(&e, &postcon);
                                                                                 ^~
./src/Inference.h:37:40: note: passing argument to parameter 'component' here
Event Inference_BeliefDeduction(Event *component, Implication *compound);
                                       ^
./src/Cycle.c:29:122: warning: incompatible pointer types passing 'Event **' to parameter of type 'Event *'; remove & [-Wincompatible-pointer-types]
            Event res = e->type == EVENT_TYPE_BELIEF ? Inference_BeliefDeduction(&e, &postcon) : Inference_GoalAbduction(&e, &postcon);
                                                                                                                         ^~
./src/Inference.h:43:38: note: passing argument to parameter 'component' here
Event Inference_GoalAbduction(Event *component, Implication *compound);
                                     ^
./src/Cycle.c:43:82: warning: incompatible pointer types passing 'Event **' to parameter of type 'Event *'; remove & [-Wincompatible-pointer-types]
            Event res = e->type == EVENT_TYPE_BELIEF ? Inference_BeliefAbduction(&e, &precon) : Inference_GoalDeduction(&e, &precon);
                                                                                 ^~
./src/Inference.h:41:40: note: passing argument to parameter 'component' here
Event Inference_BeliefAbduction(Event *component, Implication *compound);
                                       ^
./src/Cycle.c:43:121: warning: incompatible pointer types passing 'Event **' to parameter of type 'Event *'; remove & [-Wincompatible-pointer-types]
            Event res = e->type == EVENT_TYPE_BELIEF ? Inference_BeliefAbduction(&e, &precon) : Inference_GoalDeduction(&e, &precon);
                                                                                                                        ^~
./src/Inference.h:39:38: note: passing argument to parameter 'component' here
Event Inference_GoalDeduction(Event *component, Implication *compound);
                                     ^
./src/Cycle.c:58:58: warning: incompatible pointer types passing 'Event **' to parameter of type 'Event *'; remove & [-Wincompatible-pointer-types]
        int closest_concept_i = Memory_getClosestConcept(&e);
                                                         ^~
./src/Memory.h:43:37: note: passing argument to parameter 'event' here
int Memory_getClosestConcept(Event *event);

./src/main.c:11:16: warning: format string is not a string literal (potentially insecure) [-Wformat-security]
        printf(message);
               ^~~~~~~
./src/main.c:11:16: note: treat the string as an argument to avoid this
        printf(message);
               ^
               "%s",
```